### PR TITLE
Whitelist standard groovy methods

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -6,6 +6,7 @@ method java.io.PrintWriter print java.lang.String
 method java.lang.CharSequence length
 method java.lang.Comparable compareTo java.lang.Object
 method java.lang.Object equals java.lang.Object
+method java.lang.Object getClass
 method java.lang.Object toString
 staticMethod java.util.Arrays toString java.lang.Object[]
 method java.util.Collection add java.lang.Object
@@ -56,6 +57,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Obj
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.String groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods disjoint java.util.Collection java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Collection java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.String java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Collection java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods or java.lang.Boolean java.lang.Boolean
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods xor java.lang.Boolean java.lang.Boolean


### PR DESCRIPTION
Whitelist DefaultGroovyMethod plus, and Object.getClass method.

@reviewbybees
